### PR TITLE
Fix git default branch script

### DIFF
--- a/home/private_dot_config/private_fish/functions/__git.default_branch.fish
+++ b/home/private_dot_config/private_fish/functions/__git.default_branch.fish
@@ -16,8 +16,8 @@ function __git.default_branch
     end
 
     # Fetch remote information to ensure we have the latest default branch info, 
-    # cleaning up any references that doesn't exist anymore.
-    git remote update $remote --prune
+    # cleaning up any references that doesn't exist anymore, while suppressing direct output
+    git remote update $remote --prune > /dev/null 2>&1
 
     # Extract the default branch name from the 'HEAD branch' line of the 'git remote show' output
     set -l default_branch (git remote show $remote | grep 'HEAD branch' | sed 's/.*: //')


### PR DESCRIPTION
Fix the git default branch script by suppressing output to prevent any unintentional use of the output on subsequent commands. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the cleanliness of the output by suppressing direct output from the `git remote update` command in the version control functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->