### PR TITLE
Fix \n not being escaped properly

### DIFF
--- a/home/.chezmoiscripts/run_once_after_00-passwordless-sudo.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_00-passwordless-sudo.sh.tmpl
@@ -23,7 +23,7 @@ setup_passwordless_sudo() {
     echo "No sudoer file found for passwordless operation."
     bot "Enabling passwordless sudo can reduce security. Are you sure you want to proceed?"
 
-    if prompt "Make sudo passwordless? [y/N]"; then
+    if prompt "Make sudo passwordless?"; then
       # Ensure sudoers.d is included and directory exists
       if ! sudo grep -q "$includedir_line" /etc/sudoers; then
         echo "$includedir_line" | sudo tee -a /etc/sudoers > /dev/null
@@ -32,7 +32,7 @@ setup_passwordless_sudo() {
 
       # Add NOPASSWD entry for the user
       local tmpfile=$(mktemp)
-      echo "Defaults:$LOGNAME !requiretty\n$LOGNAME ALL=(ALL) NOPASSWD: ALL" > "$tmpfile"
+      echo -e "Defaults:$LOGNAME !requiretty\n$LOGNAME ALL=(ALL) NOPASSWD: ALL" > "$tmpfile"
       if sudo visudo -cf "$tmpfile" && sudo mv "$tmpfile" "$sudoers_d_dir/$LOGNAME"; then
         echo "You can now run sudo commands without a password!"
       else


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed extra `[Y/n]` that was being displayed on the prompt.
	- Improved formatting for the sudoers configuration to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->